### PR TITLE
Update dnsjava to 3.6.0 to fix CVE.

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:paths ["src" "resources"]
  :deps {org.clojure/clojure {:mvn/version "1.11.1"}
         ;; for email domain MX record validation: https://github.com/dnsjava/dnsjava/blob/master/EXAMPLES.md
-        dnsjava/dnsjava {:mvn/version "3.5.2"}
+        dnsjava/dnsjava {:mvn/version "3.6.0"}
         ;; TODO: commons-net has SMTPClient: https://commons.apache.org/proper/commons-net/javadocs/api-3.6/org/apache/commons/net/smtp/SMTPClient.html#verify(java.lang.String)
         ;; commons-net/commons-net {:mvn/version "3.9.0"}
         }


### PR DESCRIPTION
https://scout.docker.com/vulnerabilities/id/CVE-2024-25638?s=github&n=dnsjava&ns=dnsjava&t=maven&vr=%3C3.6.0